### PR TITLE
Inline about content on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,101 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Francesco Paltrinieri — Personal site</title>
-    <meta http-equiv="refresh" content="0; url=about.html">
-    <link rel="canonical" href="about.html">
+    <title>About — Francesco Paltrinieri</title>
+    <meta name="description" content="Hi, I'm Fran. I work in product across early-stage to pre-IPO startups in Europe, Asia, and the US.">
+    
+    <!-- Open Graph -->
+    <meta property="og:title" content="About — Francesco Paltrinieri">
+    <meta property="og:description" content="Hi, I'm Fran. I work in product across early-stage to pre-IPO startups in Europe, Asia, and the US.">
+    <meta property="og:type" content="website">
+    
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="About — Francesco Paltrinieri">
+    <meta name="twitter:description" content="Hi, I'm Fran. I work in product across early-stage to pre-IPO startups in Europe, Asia, and the US.">
+    
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    
+    <link rel="stylesheet" href="style.css">
+    <link rel="icon" href="assets/avatar.svg" type="image/svg+xml">
 </head>
 <body>
-    <p>Redirecting to <a href="about.html">about page</a>...</p>
+    <a href="#main" class="skip-link">Skip to content</a>
+    
+    <header class="header">
+        <div class="header-content">
+            <div class="header-brand">
+                <a href="about.html" class="brand-link">
+                    <img src="assets/avatar.svg" alt="Francesco Paltrinieri" class="brand-avatar" width="32" height="32">
+                    <h1 class="brand-name">Francesco Paltrinieri</h1>
+                </a>
+            </div>
+            <nav class="nav" role="navigation" aria-label="Main navigation">
+                <a href="about.html" class="nav-link active" aria-current="page">About</a>
+                <a href="experience.html" class="nav-link">Experience</a>
+                <a href="writing.html" class="nav-link">Writing</a>
+                <a href="links.html" class="nav-link">Links</a>
+            </nav>
+        </div>
+    </header>
+
+    <main id="main" class="main">
+        
+        <div class="container">
+
+            <section class="content-section">
+                <div class="about-layout">
+                    <div class="about-content">
+                        <div class="prose">
+                            <img src="assets/francesco.jpg" alt="Francesco Paltrinieri" class="about-photo" width="120" height="120">
+                            
+                            <p>Hi, I'm Fran 👋. </p>
+                            
+                            <p>Originally from Italy, currently based in Lisbon. </p>
+                            
+                            <p>I like building and growing products, and sometimes dream of becoming a professional padel player or skier. </p>
+                            
+                            <p>I've worked across early-stage to pre-IPO startups for nearly a decade.</p>
+                            
+                            <p>Lived in Europe, North America, and Asia. Traveled to more than 40 countries.</p>
+                            
+                            <p>I studied Finance at Bocconi, briefly tried the consulting path, then quickly escaped into startups.</p>
+                            
+                            <p>I also owned and operated an e-commerce company I started with my two best friends that sold hundreds of artisanal standing desks. That was fun. </p>
+
+                            <p>I obsess about padel, skiing, and business podcasts. Sometimes I paint with watercolors.</p>
+                            
+                        </div>
+                        
+                    </div>
+                </div>
+            </section>
+
+            <section class="content-section">
+                <div class="contact-info">
+                    <div class="contact-inline">
+                        <a href="#" class="email-link" data-email="fran.paltrinieri@gmail.com">
+                            fran.paltrinieri@gmail.com
+                        </a>
+                        <span class="contact-separator">·</span>
+                        <a href="https://www.linkedin.com/in/francescopaltrinieri/" target="_blank" rel="noopener" class="contact-link">LinkedIn</a>
+                        <span class="contact-separator">·</span>
+                        <a href="https://github.com/franplt" target="_blank" rel="noopener" class="contact-link">GitHub</a>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <small>© <span id="year"></span> Francesco Paltrinieri · Lisbon</small>
+    </footer>
+
+    <div class="toast" id="copy-toast">Email copied to clipboard!</div>
+
+    <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace the meta-refresh redirect with the full about page content at the site root

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b039d3cd2c8332a7d0f818e7ba69be