### PR TITLE
Use button for email copy with clipboard support

### DIFF
--- a/about.html
+++ b/about.html
@@ -79,9 +79,9 @@
             <section class="content-section">
                 <div class="contact-info">
                     <div class="contact-inline">
-                        <a href="#" class="email-link" data-email="fran.paltrinieri@gmail.com">
+                        <button type="button" class="email-button" data-email="fran.paltrinieri@gmail.com" aria-label="Copy email address">
                             fran.paltrinieri@gmail.com
-                        </a>
+                        </button>
                         <span class="contact-separator">·</span>
                         <a href="https://www.linkedin.com/in/francescopaltrinieri/" target="_blank" rel="noopener" class="contact-link">LinkedIn</a>
                         <span class="contact-separator">·</span>

--- a/script.js
+++ b/script.js
@@ -128,11 +128,11 @@ function initExperienceTimeline() {
 
 // Contact form functionality
 function initContactForm() {
-    const emailLink = document.querySelector('.email-link');
+    const emailButton = document.querySelector('.email-button');
     const toast = document.getElementById('copy-toast');
-    
-    if (emailLink && toast) {
-        emailLink.addEventListener('click', function(e) {
+
+    if (emailButton && toast) {
+        emailButton.addEventListener('click', function(e) {
             e.preventDefault();
             const email = this.getAttribute('data-email');
             

--- a/style.css
+++ b/style.css
@@ -475,23 +475,6 @@ body {
     margin-bottom: var(--space-2xl);
 }
 
-.email-button {
-    background: var(--accent-color);
-    color: white;
-    border: none;
-    padding: var(--space-md) var(--space-xl);
-    border-radius: 8px;
-    font-size: var(--font-size-lg);
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    font-family: inherit;
-}
-
-.email-button:hover {
-    background: var(--accent-hover);
-    transform: translateY(-1px);
-}
 
 .contact-note {
     color: var(--text-muted);
@@ -507,14 +490,21 @@ body {
     flex-wrap: wrap;
 }
 
-.email-link {
+.email-button {
     color: var(--accent-color);
     text-decoration: none;
+    font-family: inherit;
+    font-size: inherit;
     font-weight: 500;
     transition: color 0.2s ease;
+    background: none;
+    border: none;
+    border-radius: 0;
+    padding: 0;
+    cursor: pointer;
 }
 
-.email-link:hover {
+.email-button:hover {
     color: var(--accent-hover);
 }
 
@@ -720,10 +710,6 @@ a:not(.nav-link):not(.resume-button):not(.email-button):not(.error-link):hover {
         height: 80px;
     }
     
-    .email-button {
-        font-size: var(--font-size-base);
-        padding: var(--space-sm) var(--space-lg);
-    }
 }
 
 /* Print styles */


### PR DESCRIPTION
## Summary
- replace email anchor with button and add accessible label
- update copy-to-clipboard logic to target new button class
- style email button to match link appearance

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b039ddc1b083329c04112f1cf86344