### PR TITLE
Add noreferrer to external links

### DIFF
--- a/about.html
+++ b/about.html
@@ -83,9 +83,9 @@
                             fran.paltrinieri@gmail.com
                         </a>
                         <span class="contact-separator">·</span>
-                        <a href="https://www.linkedin.com/in/francescopaltrinieri/" target="_blank" rel="noopener" class="contact-link">LinkedIn</a>
+                        <a href="https://www.linkedin.com/in/francescopaltrinieri/" target="_blank" rel="noopener noreferrer" class="contact-link">LinkedIn</a>
                         <span class="contact-separator">·</span>
-                        <a href="https://github.com/franplt" target="_blank" rel="noopener" class="contact-link">GitHub</a>
+                        <a href="https://github.com/franplt" target="_blank" rel="noopener noreferrer" class="contact-link">GitHub</a>
                     </div>
                 </div>
             </section>

--- a/links.html
+++ b/links.html
@@ -57,28 +57,28 @@
                 <div class="links-grid">
                     <div class="link-item">
                         <h3 class="link-title">
-                            <a href="https://stratechery.com" target="_blank" rel="noopener">Stratechery</a>
+                            <a href="https://stratechery.com" target="_blank" rel="noopener noreferrer">Stratechery</a>
                         </h3>
                         <p class="link-description">Ben Thompson's analysis on tech strategy</p>
                     </div>
                     
                     <div class="link-item">
                         <h3 class="link-title">
-                            <a href="https://www.reforge.com/blog" target="_blank" rel="noopener">Reforge</a>
+                            <a href="https://www.reforge.com/blog" target="_blank" rel="noopener noreferrer">Reforge</a>
                         </h3>
                         <p class="link-description">Growth and product insights</p>
                     </div>
                     
                     <div class="link-item">
                         <h3 class="link-title">
-                            <a href="https://lenny.substack.com" target="_blank" rel="noopener">Lenny's Newsletter</a>
+                            <a href="https://lenny.substack.com" target="_blank" rel="noopener noreferrer">Lenny's Newsletter</a>
                         </h3>
                         <p class="link-description">Product management wisdom</p>
                     </div>
                     
                     <div class="link-item">
                         <h3 class="link-title">
-                            <a href="https://www.producthunt.com" target="_blank" rel="noopener">Product Hunt</a>
+                            <a href="https://www.producthunt.com" target="_blank" rel="noopener noreferrer">Product Hunt</a>
                         </h3>
                         <p class="link-description">Daily dose of new products</p>
                     </div>

--- a/script.js
+++ b/script.js
@@ -110,7 +110,7 @@ function initExperienceTimeline() {
         
         // Create company link if URL exists
         const companyText = role.url ? 
-            `<a href="${role.url}" target="_blank" rel="noopener">${role.company}</a>` : 
+            `<a href="${role.url}" target="_blank" rel="noopener noreferrer">${role.company}</a>` : 
             role.company;
         
         timelineItem.innerHTML = `

--- a/writing.html
+++ b/writing.html
@@ -57,7 +57,7 @@
                 <div class="writing-list">
                     <article class="writing-item">
                         <h3 class="writing-title">
-                            <a href="#" target="_blank" rel="noopener" class="writing-link">
+                            <a href="#" target="_blank" rel="noopener noreferrer" class="writing-link">
                                 Daily Token — AI fundamentals in 10 days
                                 <svg class="external-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
                                     <path d="M3.5 3C3.22386 3 3 3.22386 3 3.5C3 3.77614 3.22386 4 3.5 4H7.29289L3.14645 8.14645C2.95118 8.34171 2.95118 8.65829 3.14645 8.85355C3.34171 9.04882 3.65829 9.04882 3.85355 8.85355L8 4.70711V8.5C8 8.77614 8.22386 9 8.5 9C8.77614 9 9 8.77614 9 8.5V3.5C9 3.22386 8.77614 3 8.5 3H3.5Z" fill="currentColor"/>
@@ -69,7 +69,7 @@
                     
                     <article class="writing-item">
                         <h3 class="writing-title">
-                            <a href="#" target="_blank" rel="noopener" class="writing-link">
+                            <a href="#" target="_blank" rel="noopener noreferrer" class="writing-link">
                                 Something I'm writing now
                                 <svg class="external-icon" width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
                                     <path d="M3.5 3C3.22386 3 3 3.22386 3 3.5C3 3.77614 3.22386 4 3.5 4H7.29289L3.14645 8.14645C2.95118 8.34171 2.95118 8.65829 3.14645 8.85355C3.34171 9.04882 3.65829 9.04882 3.85355 8.85355L8 4.70711V8.5C8 8.77614 8.22386 9 8.5 9C8.77614 9 9 8.77614 9 8.5V3.5C9 3.22386 8.77614 3 8.5 3H3.5Z" fill="currentColor"/>


### PR DESCRIPTION
## Summary
- ensure external links on about, writing, and links pages use `rel="noopener noreferrer"`
- update generated experience links in script.js to include `rel="noopener noreferrer"`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b039e5985c833296cb9c6b9c184422